### PR TITLE
Capture package store from our parent Meteor process

### DIFF
--- a/isopacks.js
+++ b/isopacks.js
@@ -4,14 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const log = require('./log');
 
-// TODO: add support for running Meteor from checkout
-let meteorParentDir = process.platform === 'win32' ?
-  process.env.LOCALAPPDATA :
-  process.env.HOME;
-
-let remoteCatalogPath = path.join(meteorParentDir, '.meteor', 'packages');
-
-module.exports = function loadPackages(appPath, catalog) {
+module.exports = function loadPackages(appPath, catalog, remoteCatalogRoot) {
   var contents;
   try {
     contents = fs.readFileSync(path.resolve(appPath, '.meteor/versions'), 'utf-8');
@@ -39,7 +32,7 @@ module.exports = function loadPackages(appPath, catalog) {
     if (packageVersion.package in packages)
       return;
 
-    var result = findPackagePath(appPath, packageVersion.package, packageVersion.version, catalog);
+    var result = findPackagePath(appPath, packageVersion.package, packageVersion.version, catalog, remoteCatalogRoot);
     packages[packageVersion.package] = {
       remote: result.remote,
       version: packageVersion.version,
@@ -102,7 +95,7 @@ function readIsopack(packagePath, remote) {
 
 let packagePathCache = Object.create(null);
 
-function findPackagePath(appPath, name, version, catalog) {
+function findPackagePath(appPath, name, version, catalog, remoteCatalogRoot) {
   let checkLocal = true;
 
   if (catalog) {
@@ -131,7 +124,8 @@ function findPackagePath(appPath, name, version, catalog) {
   }
 
   let remotePath = path.join(
-    remoteCatalogPath,
+    remoteCatalogRoot,
+    'packages',
     name.replace(':', '_'),
     version
   );

--- a/tools-imports.js
+++ b/tools-imports.js
@@ -8,5 +8,6 @@ const toolsRequire = function (filePath) {
 
 module.exports = {
   PackageSource: toolsRequire('isobuild/package-source'),
-  ProjectContext: toolsRequire('./project-context').ProjectContext
+  ProjectContext: toolsRequire('./project-context').ProjectContext,
+  tropohouse: toolsRequire('./tropohouse').default,
 }

--- a/types.js
+++ b/types.js
@@ -3,6 +3,7 @@ var loadPackages = require('./isopacks.js');
 var findTypesEntry = require('./types-entry.js');
 var Writer = require('./writer.js');
 const ProjectContext = require('./tools-imports.js').ProjectContext;
+const tropohouse = require('./tools-imports.js').tropohouse;
 const path = require('path');
 const fs = require('fs');
 
@@ -19,6 +20,8 @@ ProjectContext.prototype.getProjectLocalDirectory = function () {
 
   return oldGetProjectLocalDirectory.apply(this, arguments);
 };
+
+const remoteCatalogRoot = tropohouse.root;
 
 const isLinting = process.argv.includes('lint');
 
@@ -67,7 +70,7 @@ class Linter {
       setupFinished = true;
     }
 
-    var packages = loadPackages(appPath, catalog);
+    var packages = loadPackages(appPath, catalog, remoteCatalogRoot);
 
     for(var entry of Object.entries(packages)) {
       var name = entry[0];


### PR DESCRIPTION
Capture package store from our parent Meteor process

When running with a Meteor checkout, instead of a released version of Meteor, Meteor creates a `.meteor` directory in its own source tree, rather than using the `.meteor` directory in `$HOME` or `$LOCALDATA`. This means that when we use `zodern:types` in (e.g.) a self-test, such as the one added in meteor/meteor#12510, packages would not end up where we expected them.

Unfortunately, when the package is published, it gets loaded after Meteor has already parsed the project context.

So instead of reaching into Meteor's ProjectContext to get the package catalog, we instead create our own temporary context, following the example of what Meteor does for `meteor show`. Once we've done that, we can grab both the package catalog and the root of the package store.

(You can see that test failing here: https://app.circleci.com/pipelines/github/meteor/meteor/4789/workflows/c5a5aa13-85a4-4845-8b0a-b93d7fa00c3a/jobs/99770/tests)