### PR TITLE
Only register .d.ts compiler when publishing

### DIFF
--- a/publish-packages.js
+++ b/publish-packages.js
@@ -11,24 +11,27 @@ const PackageSource = require('./tools-imports.js').PackageSource;
 // 2) Generate types if needed
 // 3) Uninstall npm dev dependencies, and reinstall them after publishing
 
-Plugin.registerCompiler({
-  // These aren't used by the compiler
-  // This ensures meteor includes these files when building or publishing
-  // the package
-  extensions: ['d.ts', 'd.ts.map'],
-  filenames: ['package-types.json']
-}, () => new PackageCompiler());
+// Probably isn't completely reliable, but is close enough
+const isPublish = process.argv.includes('publish');
 
-class PackageCompiler {
-  processFilesForTarget(files) {
-    // Do nothing
-    // Meteor Typescript compilers usually ignore .d.ts files
-    // and package-types.json are not used during runtime
+if (isPublish) {
+  Plugin.registerCompiler({
+    // These aren't used by the compiler
+    // This ensures meteor includes these files when building or publishing
+    // the package
+    extensions: ['d.ts', 'd.ts.map'],
+    filenames: ['package-types.json']
+  }, () => new PackageCompiler());
+
+  class PackageCompiler {
+    processFilesForTarget(files) {
+      // Do nothing
+      // Meteor Typescript compilers usually ignore .d.ts files
+      // and package-types.json are not used during runtime
+    }
   }
 }
 
-// Probably isn't completely reliable, but is close enough
-const isPublish = process.argv.includes('publish');
 const packagePath = process.cwd();
 let prepared = false;
 


### PR DESCRIPTION
Only calling `Plugin.registerCompiler` when publishing fixes #12 for us.

Fixes #12