### PR TITLE
Feature/configurable symlink paths

### DIFF
--- a/types.js
+++ b/types.js
@@ -9,7 +9,12 @@ const fs = require('fs');
 const log = require('./log.js');
 
 var appPath = process.cwd();
-var writer = new Writer(appPath);
+const remoteCatalogRoot = (
+	process.platform == "win32"
+) ? 
+	Plugin.convertToOSPath( tropohouse.root ) 
+: tropohouse.root;
+var writer = new Writer(appPath, remoteCatalogRoot);
 
 var catalog;
 var setupFinished = false;
@@ -22,11 +27,6 @@ ProjectContext.prototype.getProjectLocalDirectory = function () {
   return oldGetProjectLocalDirectory.apply(this, arguments);
 };
 
-let remoteCatalogRoot = (
-    process.platform == "win32"
-  ) ? 
-    Plugin.convertToOSPath( tropohouse.root ) 
-  : tropohouse.root;
 
 const isLinting = process.argv.includes('lint');
 

--- a/types.js
+++ b/types.js
@@ -6,6 +6,7 @@ const ProjectContext = require('./tools-imports.js').ProjectContext;
 const tropohouse = require('./tools-imports.js').tropohouse;
 const path = require('path');
 const fs = require('fs');
+const log = require('./log.js');
 
 var appPath = process.cwd();
 var writer = new Writer(appPath);
@@ -73,6 +74,11 @@ class Linter {
       writer.setup();
       setupFinished = true;
     }
+
+		log('paths',{
+			appPath,
+			remoteCatalogRoot
+		})
 
     var packages = loadPackages(appPath, catalog, remoteCatalogRoot);
 

--- a/writer.js
+++ b/writer.js
@@ -4,7 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const log = require('./log.js');
 
-const shouldOverrideSymlinkTarget = process.env.SYMLINK_REMOTE_CATALOG_ROOT && process.env.SYMLINK_APP_PATH;
+const shouldOverrideSymlinkTarget = process.env.ZODERN_TYPES_SYMLINK_REMOTE_CATALOG_ROOT && process.env.ZODERN_TYPES_SYMLINK_APP_PATH;
+const symlinkOverrides = {
+	remoteCatalogRoot: process.env.ZODERN_TYPES_SYMLINK_REMOTE_CATALOG_ROOT,
+	appPath: process.env.ZODERN_TYPES_SYMLINK_APP_PATH
+}
 
 // Manages the files and folders in .meteor/local/types
 module.exports = class Writer {
@@ -91,7 +95,7 @@ module.exports = class Writer {
 		// symlink target path
 		const isRemote = path.includes(this.remoteCatalogRoot);
 		const pathToReplace	= isRemote ? this.remoteCatalogRoot : this.appPath;
-		const reaplacementPath = isRemote ? process.env.SYMLINK_REMOTE_CATALOG_ROOT : process.env.SYMLINK_APP_PATH;
+		const reaplacementPath = isRemote ? symlinkOverrides.remoteCatalogRoot : symlinkOverrides.appPath;
 
 		return path.replace(pathToReplace, reaplacementPath);
 	}


### PR DESCRIPTION
### What
Allow to override appPath and remoteCataloogRoot when writing symlinks with paths from env variables

### Why
I have a very specific case where runtime exists in a different environment from development, so using this package I end up having symlinks that don't make sense for my system and IDE.
Locally I run meteor project dockerized with tilt. Outputs are reflected in my system because everything is mounted, but since process runs inside container zodern:types ends up generating symlinks that are resolvable only inside container.
So my solution is to manually provide paths for app and catalog root on host machine and pass them down in the container so that symlinks created by package are readable by host.

I didn't update anything in Readme regarding adding the variables since it's a very specific case and variables if misused can break functionality, so unless someone knows what they are doing they shouldn't touch that. But I can add it to readme if needed